### PR TITLE
fixed issue where config auto discovery value wasn't being set

### DIFF
--- a/AmazonWebServicesFactory.php
+++ b/AmazonWebServicesFactory.php
@@ -45,6 +45,22 @@ class AmazonWebServicesFactory
     );
 
     /**
+     * Constructor
+     *
+     * @param array $config     The user defined config
+     */
+    public function __construct(array $config)
+    {
+        if ($config['disable_auto_config'] && (! defined('AWS_DISABLE_CONFIG_AUTO_DISCOVERY'))) {
+            define('AWS_DISABLE_CONFIG_AUTO_DISCOVERY', TRUE);
+        }
+
+        if (isset($config['sdk_path']) && file_exists($config['sdk_path'])) {
+            require_once $config['sdk_path'];
+        }
+    }
+
+    /**
      * Get an Amazon Web Service object
      *
      * @param  AmazonWebServices $aws         An AmazonWebServices Service instance

--- a/DependencyInjection/CybernoxAmazonWebServicesExtension.php
+++ b/DependencyInjection/CybernoxAmazonWebServicesExtension.php
@@ -37,8 +37,7 @@ class CybernoxAmazonWebServicesExtension extends Extension
             $container->setParameter('cybernox_amazon_web_services.' . $key, $value);
         }
 
-        if ($config['disable_auto_config'] && (! defined('AWS_DISABLE_CONFIG_AUTO_DISCOVERY'))) {
-            define('AWS_DISABLE_CONFIG_AUTO_DISCOVERY', TRUE);
-        }
+        $factory = $container->getDefinition('aws_factory');
+        $factory->addArgument($config);
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -31,7 +31,6 @@
         <service id="aws_factory" class="%aws_factory.class%"/>
 
         <service id="aws_service" class="AwsService" factory-service="aws_factory" factory-method="get" abstract="true">
-            <file>%cybernox_amazon_web_services.sdk_path%</file>
             <argument type="service" id="aws"/>
         </service>
 


### PR DESCRIPTION
Basically config auto discovery option was being set as a global in the factory loader.  The factory loader produced classes that were then cached without the define statement being run, so when they were used, the auto discovery wasn't being set again.  The only time it should work (before this fix) is right after a Symofny cache clear, then it would be set again when the factory classes were being loaded.

to fix, I push the config to the factory class constructor.  then, when the classes load, they are able to set the global config value for auto config discovery every time they run.